### PR TITLE
Reuse actions

### DIFF
--- a/.github/actions/setup-java/action.yml
+++ b/.github/actions/setup-java/action.yml
@@ -1,0 +1,9 @@
+name: Setup Java
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-java@v5
+      with:
+        distribution: temurin
+        java-version: '17'

--- a/.github/actions/setup-java/action.yml
+++ b/.github/actions/setup-java/action.yml
@@ -7,3 +7,4 @@ runs:
       with:
         distribution: temurin
         java-version: '17'
+        cache: gradle

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 3
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: '17'
+      - uses: ./.github/actions/setup-java
 
       - run: ./gradlew testDebugUnitTest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: Android CI
 on:
   push:
   pull_request:
+  workflow_call:
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: Android CI
 
 on:
   push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
   pull_request:
   workflow_call:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,12 @@ on:
   push:
     branches:
       - '**'
+    # Tags are ignored since the release workflow calls this workflow
+    # directly.
     tags-ignore:
       - '**'
   pull_request:
+  # Allow this workflow to be called by other workflows.
   workflow_call:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: '17'
+      - uses: ./.github/actions/setup-java
+
+      - run: ./gradlew testDebugUnitTest
 
       - name: Extract version from tag
         id: version
@@ -33,8 +32,6 @@ jobs:
           
           echo "Version name: $TAG"
           echo "Version code: $CODE"
-
-      - run: ./gradlew testDebugUnitTest
 
       - name: Decode keystore
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,9 @@ on:
       - 'v*'
 
 permissions:
-  contents: write
-  id-token: write
-  attestations: write
+  contents: write      # Required to create the GitHub release and upload the APK
+  id-token: write      # Required to request the OIDC token for build attestation
+  attestations: write  # Required to persist the build provenance attestation
 
 jobs:
   test:
@@ -23,6 +23,9 @@ jobs:
 
       - uses: ./.github/actions/setup-java
 
+      # Extract VERSION_NAME (e.g. "1.2.3") and VERSION_CODE (e.g. 1002003)
+      # from the git tag (e.g. "v1.2.3"). VERSION_CODE uses the formula
+      # major*1000000 + minor*1000 + patch so it is always increasing.
       - name: Extract version from tag
         id: version
         run: |
@@ -35,6 +38,7 @@ jobs:
           echo "Version name: $TAG"
           echo "Version code: $CODE"
 
+      # The keystore is stored as a base64-encoded environment secret
       - name: Decode keystore
         run: |
           echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > "$RUNNER_TEMP/release-keystore.jks"
@@ -58,6 +62,9 @@ jobs:
           mv app/build/outputs/apk/release/app-release.apk "$APK_NAME"
           echo "APK_NAME=$APK_NAME" >> "$GITHUB_OUTPUT"
 
+      # Generates attestation for the APK, allowing users to verify the binary
+      # was built by this workflow. Skipped for private repos since that is not
+      # supported.
       - name: Attest build provenance
         if: ${{ !github.event.repository.private }}
         uses: actions/attest-build-provenance@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,25 +11,27 @@ permissions:
   attestations: write
 
 jobs:
+  test:
+    uses: ./.github/workflows/ci.yml
+
   release:
     runs-on: ubuntu-latest
+    needs: test
 
     steps:
       - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-java
 
-      - run: ./gradlew testDebugUnitTest
-
       - name: Extract version from tag
         id: version
         run: |
           TAG="${GITHUB_REF#refs/tags/v}"
           echo "VERSION_NAME=$TAG" >> "$GITHUB_OUTPUT"
-          
+
           CODE=$(echo "$TAG" | awk -F. '{print $1 * 1000000 + $2 * 1000 + $3}')
           echo "VERSION_CODE=$CODE" >> "$GITHUB_OUTPUT"
-          
+
           echo "Version name: $TAG"
           echo "Version code: $CODE"
 


### PR DESCRIPTION
- Create a shared action for java setup and enable cache
- Adjust release workflow to call ci action instead duplicating
- Enable dependabot